### PR TITLE
Support waking a service via the private network

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -13,6 +13,20 @@
 	}
 }
 
+(lb_settings) {
+	lb_policy round_robin
+	lb_retries 100
+	lb_try_duration 10s
+	lb_try_interval 250ms
+}
+
+(passive_health_checks) {
+	fail_duration 60s
+	max_fails 300
+	unhealthy_latency 5s
+	unhealthy_request_count 200
+}
+
 # site block, listens on the $PORT environment variable, automatically assigned by railway
 :{$PORT} {
 	# access logs
@@ -20,22 +34,53 @@
 		format json # set access log format to json mode
 	}
 
-	reverse_proxy {$FRONTEND_HOST} # proxy all requests for /* to the frontend, configure this variable in the service settings
+	# proxy all requests for /* to the frontend, configure these variables in the service settings
+	reverse_proxy {
+		# for private networking replicas are exposed as multiple dns results, use those dns results as the upstreams
+		dynamic a {
+			name {$FRONTEND_DOMAIN}
+			port {$FRONTEND_PORT}
+			refresh 1s
+			dial_timeout 30s
+			versions ipv4 ipv6
+		}
 
-	# the handle_path directive WILL strip /api/ from the path before proxying
-	# this is needed if your backend's api routes don't start with /api/
-	# change paths as needed
-	handle_path /api/* {
-		# the /api/ prefix WILL be stripped from the uri sent to the proxy host
-		reverse_proxy {$BACKEND_HOST} # proxy all requests for /api/* to the backend, configure this variable in the service settings
+		# configure load balancing settings
+		import lb_settings
+
+		# configure passive health checks
+		import passive_health_checks
+
+		# sets the Host header to the header to the dynamic name and port options
+		header_up Host {upstream_hostport}
 	}
 
-	# this handle directive will NOT strip /api/ from the path before proxying
-	# if your backend's api routes do start with /api/ then you wouldn't want to strip the path prefix
-	# if so, comment out the above handle_path and reverse_proxy directives, and uncomment these handle and reverse_proxy directives
+	# the handle_path directive WILL strip /api/ from the path before proxying
+	# use `handle` instead of `handle_path` if you dont want to strip the /api/ path
+	# this is needed if your backend's api routes don't start with /api/
 	# change paths as needed
-	# handle /api/* {
-	# the /api/ prefix will NOT be stripped from the uri sent to the proxy host
-	# reverse_proxy {$BACKEND_HOST} # proxy all requests for /api/* to the backend, configure this variable in the service settings
-	# }
+	handle_path {$BACKEND_PATH:/api}/* {
+		# the /api/ prefix WILL be stripped from the uri sent to the proxy host
+		#
+		# proxy all requests for /api/* to the backend, configure this variable in the service settings
+		reverse_proxy {
+			# for private networking replicas are exposed as multiple dns results, use those dns results as the upstreams
+			dynamic a {
+				name {$BACKEND_DOMAIN}
+				port {$BACKEND_PORT}
+				refresh 1s
+				dial_timeout 30s
+				versions ipv4 ipv6
+			}
+
+			# configure load balancing settings
+			import lb_settings
+
+			# configure passive health checks
+			import passive_health_checks
+
+			# sets the Host header to the header to the dynamic name and port options
+			header_up Host {upstream_hostport}
+		}
+	}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 FROM caddy:latest
 
-COPY Caddyfile /etc/caddy/Caddyfile
+WORKDIR /app
 
-RUN caddy fmt --overwrite /etc/caddy/Caddyfile
+COPY Caddyfile ./
 
-CMD exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile 2>&1
+COPY --chmod=755 entrypoint.sh ./
+
+RUN caddy fmt --overwrite Caddyfile
+
+ENTRYPOINT ["/bin/sh"]
+
+CMD ["entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -euo pipefail
+
+# for backwards compatibility, seperates host and port from url
+export FRONTEND_DOMAIN=${FRONTEND_DOMAIN:-${FRONTEND_HOST%:*}}
+export FRONTEND_PORT=${FRONTEND_PORT:-${FRONTEND_HOST##*:}}
+
+export BACKEND_DOMAIN=${BACKEND_DOMAIN:-${BACKEND_HOST%:*}}
+export BACKEND_PORT=${BACKEND_PORT:-${BACKEND_HOST##*:}}
+
+# strip https:// or https:// from domain if necessary
+FRONTEND_DOMAIN=${FRONTEND_DOMAIN##*://}
+BACKEND_DOMAIN=${BACKEND_DOMAIN##*://}
+
+echo using frontend: ${FRONTEND_DOMAIN} with port: ${FRONTEND_PORT}
+echo using backend: ${BACKEND_DOMAIN} with port: ${BACKEND_PORT}
+
+exec caddy run --config Caddyfile --adapter caddyfile 2>&1


### PR DESCRIPTION
Adds the needed passive health checks to retry connections to slept services.

Also changes to a dynamic upstream proxy resolver to give finer control over how caddy communicates with upstream replicas.